### PR TITLE
fix log to standard out

### DIFF
--- a/lib/fastlane/plugin/unity/actions/unity_action.rb
+++ b/lib/fastlane/plugin/unity/actions/unity_action.rb
@@ -27,7 +27,7 @@ module Fastlane
         cmd << " -cacheServerEnableDownload #{params[:cache_server_enable_download]}" unless params[:cache_server_enable_download].nil?
         cmd << " -cacheServerEnableUpload #{params[:cache_server_enable_upload]}" unless params[:cache_server_enable_upload].nil?
 
-        cmd << " -logfile"
+        cmd << " -logfile -"
         cmd << " #{params[:extra_args]}" if params[:extra_args]
 
         FastlaneCore::CommandExecutor.execute(


### PR DESCRIPTION
According to [this post](https://discussions.unity.com/t/redirecting-build-output-to-console-for-automated-builds/128805/6) it is required to use `-logfile -` to output to standard out.

We could also consider adding an options parameter for logfile so it could be outputted to a file and perhaps default the option to `-` ? 🤔